### PR TITLE
[DO NOT MERGE] Add orientation and wave size properties to linear gradient

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@
 
 trigger:
 - master
+pr: none
 
 pool:
   vmImage: 'windows-latest'

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Brushes/LinearGradientBrush.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Brushes/LinearGradientBrush.cs
@@ -18,9 +18,13 @@ namespace Artemis.Plugins.LayerBrushes.Color
                 SKMatrix.CreateTranslation(_scrollX, _scrollY),
                 SKMatrix.CreateRotationDegrees(Properties.Rotation, bounds.MidX, bounds.MidY)
             );
+
             paint.Shader = SKShader.CreateLinearGradient(
                 new SKPoint(bounds.Left, bounds.Top),
-                new SKPoint(bounds.Right, bounds.Top),
+                new SKPoint(
+                    ((Properties.Orientation == LinearGradientOrientatonMode.Horizontal) ? bounds.Right : bounds.Left) * Properties.WaveSize / 100,
+                    ((Properties.Orientation == LinearGradientOrientatonMode.Horizontal) ? bounds.Top : bounds.Bottom) * Properties.WaveSize / 100
+                    ),
                 Properties.Colors.BaseValue.GetColorsArray(Properties.ColorsMultiplier),
                 Properties.Colors.BaseValue.GetPositionsArray(Properties.ColorsMultiplier),
                 SKShaderTileMode.Repeat,
@@ -45,8 +49,8 @@ namespace Artemis.Plugins.LayerBrushes.Color
 
         public override void Update(double deltaTime)
         {
-            _scrollX += Properties.ScrollSpeed.CurrentValue.X * 10 * (float) deltaTime;
-            _scrollY += Properties.ScrollSpeed.CurrentValue.Y * 10 * (float) deltaTime;
+            _scrollX += Properties.ScrollSpeed.CurrentValue.X * 10 * (float)deltaTime;
+            _scrollY += Properties.ScrollSpeed.CurrentValue.Y * 10 * (float)deltaTime;
         }
 
         #endregion

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Brushes/LinearGradientBrush.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Brushes/LinearGradientBrush.cs
@@ -1,6 +1,7 @@
 ﻿using Artemis.Core.LayerBrushes;
 using Artemis.Plugins.LayerBrushes.Color.PropertyGroups;
 using SkiaSharp;
+using System;
 
 namespace Artemis.Plugins.LayerBrushes.Color
 {
@@ -27,9 +28,10 @@ namespace Artemis.Plugins.LayerBrushes.Color
                     ),
                 Properties.Colors.BaseValue.GetColorsArray(0),
                 Properties.Colors.BaseValue.GetPositionsArray(0),
-                SKShaderTileMode.Repeat,
+                (SKShaderTileMode)Enum.ToObject(typeof(SKShaderTileMode), Properties.RepeatMode),
                 matrix
             );
+
             canvas.DrawRect(bounds, paint);
             paint.Shader?.Dispose();
             paint.Shader = null;

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Brushes/LinearGradientBrush.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Brushes/LinearGradientBrush.cs
@@ -25,8 +25,8 @@ namespace Artemis.Plugins.LayerBrushes.Color
                     ((Properties.Orientation == LinearGradientOrientatonMode.Horizontal) ? bounds.Right : bounds.Left) * Properties.WaveSize / 100,
                     ((Properties.Orientation == LinearGradientOrientatonMode.Horizontal) ? bounds.Top : bounds.Bottom) * Properties.WaveSize / 100
                     ),
-                Properties.Colors.BaseValue.GetColorsArray(Properties.ColorsMultiplier),
-                Properties.Colors.BaseValue.GetPositionsArray(Properties.ColorsMultiplier),
+                Properties.Colors.BaseValue.GetColorsArray(0),
+                Properties.Colors.BaseValue.GetPositionsArray(0),
                 SKShaderTileMode.Repeat,
                 matrix
             );

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
@@ -13,7 +13,7 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         [PropertyDescription(Description = "Change the rotation of the gradient without affecting the rotation of the shape", InputAffix = "°")]
         public IntLayerProperty WaveSize { get; set; }
 
-        [PropertyDescription(Description = "Change the base orientation of the gradient", InputAffix = "°")]
+        [PropertyDescription(Description = "Change the base orientation of the gradient")]
         public EnumLayerProperty<LinearGradientOrientatonMode> Orientation { get; set; }
 
         [PropertyDescription(Description = "Change the lenght of the visible portion of the gradient", InputAffix = "°")]

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
@@ -1,4 +1,5 @@
 ﻿using Artemis.Core;
+using SkiaSharp;
 
 namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
 {
@@ -13,6 +14,9 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         [PropertyDescription(Description = "Change the orientation of the gradient without affecting the orientation of the shape")]
         public EnumLayerProperty<LinearGradientOrientatonMode> Orientation { get; set; }
 
+        [PropertyDescription(Description = "Change how the gradient will be handled when it is painted outside shape bounds")]
+        public EnumLayerProperty<LinearGradientRepeatmode> RepeatMode { get; set; }
+
         [PropertyDescription(Description = "Change the rotation of the gradient without affecting the rotation of the shape", InputAffix = "°")]
         public FloatLayerProperty Rotation { get; set; }
 
@@ -26,6 +30,7 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
             Colors.DefaultValue = ColorGradient.GetUnicornBarf();
             WaveSize.DefaultValue = 100;
             Orientation.DefaultValue = LinearGradientOrientatonMode.Horizontal;
+            RepeatMode.DefaultValue = LinearGradientRepeatmode.Repeat;
         }
 
         protected override void EnableProperties()
@@ -43,5 +48,11 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
     {
         Horizontal,
         Vertical
+    }
+
+    public enum LinearGradientRepeatmode
+    {
+        Repeat = 1,
+        Mirror = 2
     }
 }

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
@@ -16,7 +16,7 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         [PropertyDescription(Description = "Change the base orientation of the gradient")]
         public EnumLayerProperty<LinearGradientOrientatonMode> Orientation { get; set; }
 
-        [PropertyDescription(Description = "Change the lenght of the visible portion of the gradient", InputAffix = "°")]
+        [PropertyDescription(Description = "Change the length of the visible portion of the gradient", InputAffix = "°")]
         public FloatLayerProperty Rotation { get; set; }
 
         [PropertyDescription(Description = "The speed at which the gradient moves vertically and horizontally in cm per second.", InputAffix = "cm/s")]

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
@@ -11,6 +11,12 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         public IntLayerProperty ColorsMultiplier { get; set; }
 
         [PropertyDescription(Description = "Change the rotation of the gradient without affecting the rotation of the shape", InputAffix = "°")]
+        public IntLayerProperty WaveSize { get; set; }
+
+        [PropertyDescription(Description = "Change the base orientation of the gradient", InputAffix = "°")]
+        public EnumLayerProperty<LinearGradientOrientatonMode> Orientation { get; set; }
+
+        [PropertyDescription(Description = "Change the lenght of the visible portion of the gradient", InputAffix = "°")]
         public FloatLayerProperty Rotation { get; set; }
 
         [PropertyDescription(Description = "The speed at which the gradient moves vertically and horizontally in cm per second.", InputAffix = "cm/s")]
@@ -21,6 +27,8 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         protected override void PopulateDefaults()
         {
             Colors.DefaultValue = ColorGradient.GetUnicornBarf();
+            WaveSize.DefaultValue = 100;
+            Orientation.DefaultValue = LinearGradientOrientatonMode.Horizontal;
         }
 
         protected override void EnableProperties()
@@ -32,5 +40,11 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         }
 
         #endregion
+    }
+
+    public enum LinearGradientOrientatonMode
+    {
+        Horizontal,
+        Vertical
     }
 }

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
@@ -17,12 +17,6 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         [PropertyDescription(Description = "Change how the gradient will be handled when it is painted outside shape bounds")]
         public EnumLayerProperty<LinearGradientRepeatmode> RepeatMode { get; set; }
 
-        [PropertyDescription(Description = "Change the rotation of the gradient without affecting the rotation of the shape", InputAffix = "°")]
-        public IntLayerProperty WaveSize { get; set; }
-
-        [PropertyDescription(Description = "Change the base orientation of the gradient")]
-        public EnumLayerProperty<LinearGradientOrientatonMode> Orientation { get; set; }
-
         [PropertyDescription(Description = "Change the length of the visible portion of the gradient", InputAffix = "°")]
         public FloatLayerProperty Rotation { get; set; }
 

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/PropertyGroups/LinearGradientBrushProperties.cs
@@ -7,16 +7,13 @@ namespace Artemis.Plugins.LayerBrushes.Color.PropertyGroups
         [PropertyDescription(Description = "The gradient of the brush")]
         public ColorGradientLayerProperty Colors { get; set; }
 
-        [PropertyDescription(Name = "Colors multiplier", Description = "How many times to repeat the colors in the selected gradient", DisableKeyframes = true, MinInputValue = 0, MaxInputValue = 10)]
-        public IntLayerProperty ColorsMultiplier { get; set; }
-
-        [PropertyDescription(Description = "Change the rotation of the gradient without affecting the rotation of the shape", InputAffix = "°")]
+        [PropertyDescription(Description = "Change the length of the visible portion of the gradient", InputAffix = "%")]
         public IntLayerProperty WaveSize { get; set; }
 
-        [PropertyDescription(Description = "Change the base orientation of the gradient")]
+        [PropertyDescription(Description = "Change the orientation of the gradient without affecting the orientation of the shape")]
         public EnumLayerProperty<LinearGradientOrientatonMode> Orientation { get; set; }
 
-        [PropertyDescription(Description = "Change the length of the visible portion of the gradient", InputAffix = "°")]
+        [PropertyDescription(Description = "Change the rotation of the gradient without affecting the rotation of the shape", InputAffix = "°")]
         public FloatLayerProperty Rotation { get; set; }
 
         [PropertyDescription(Description = "The speed at which the gradient moves vertically and horizontally in cm per second.", InputAffix = "cm/s")]


### PR DESCRIPTION
Add base orientation property to easily create vertical gradients.
Add Wave Size property  to control how much of the gradient is actually visible (from the beginning of the gradient).