### PR TITLE
Support for selecting left or right channel audio in AudioVisualizati…

### DIFF
--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/FourierSpectrumProvider.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/FourierSpectrumProvider.cs
@@ -11,11 +11,13 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
 
         private readonly AudioBuffer _audioBuffer;
 
-        private float[] _sampleData;
+        private float[] _sampleDataMix;
+        private float[] _sampleDataLeft;
+        private float[] _sampleDataRight;
         private double[] _hamming;
         private Complex32[] _complexBuffer;
 
-        private float[] _spectrum;
+        private float[][] _spectrum;
         private int _usableDataLength;
 
         #endregion
@@ -34,47 +36,81 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
         public override void Initialize()
         {
             _hamming = Window.Hamming(_audioBuffer.Size);
-            _sampleData = new float[_audioBuffer.Size];
+            _sampleDataMix = new float[_audioBuffer.Size];
+            _sampleDataLeft = new float[_audioBuffer.Size];
+            _sampleDataRight = new float[_audioBuffer.Size];
             _complexBuffer = new Complex32[_audioBuffer.Size];
             _usableDataLength = (_audioBuffer.Size / 2) + 1;
-            _spectrum = new float[_usableDataLength];
+            _spectrum = new float[][] { new float[_usableDataLength], new float[_usableDataLength], new float[_usableDataLength] };
         }
 
         public override void Update()
         {
-            _audioBuffer.CopyMixInto(ref _sampleData, 0);
+            _audioBuffer.CopyMixInto(ref _sampleDataMix, 0);
+            _audioBuffer.CopyLeftInto(ref _sampleDataLeft, 0);
+            _audioBuffer.CopyRightInto(ref _sampleDataRight, 0);
 
-            ApplyHamming(ref _sampleData);
-            CreateSpectrum(ref _sampleData);
+            ApplyHamming(ref _sampleDataMix, ref _sampleDataLeft, ref _sampleDataRight);
+
+            CreateSpectrum(ref _sampleDataMix, ref _sampleDataLeft, ref _sampleDataRight);
         }
 
-        private void ApplyHamming(ref float[] data)
+        private void ApplyHamming(ref float[] dataMix, ref float[] dataLeft, ref float[] dataRight)
         {
-            for (int i = 0; i < data.Length; i++)
-                data[i] = (float)(data[i] * _hamming[i]);
+            for (int i = 0; i < dataMix.Length; i++)
+                dataMix[i] = (float)(dataMix[i] * _hamming[i]);
+            for (int i = 0; i < dataLeft.Length; i++)
+                dataLeft[i] = (float)(dataLeft[i] * _hamming[i]);
+            for (int i = 0; i < dataRight.Length; i++)
+                dataRight[i] = (float)(dataRight[i] * _hamming[i]);
         }
 
-        private void CreateSpectrum(ref float[] data)
+        private void CreateSpectrum(ref float[] dataMix, ref float[] dataLeft, ref float[] dataRight)
         {
-            for (int i = 0; i < data.Length; i++)
-                _complexBuffer[i] = new Complex32(data[i], 0);
+            // Center (mix) channel
+            for (int i = 0; i < dataMix.Length; i++)
+                _complexBuffer[i] = new Complex32(dataMix[i], 0);
 
             Fourier.Forward(_complexBuffer, FourierOptions.NoScaling);
 
-            for (int i = 0; i < _spectrum.Length; i++)
+            for (int i = 0; i < _spectrum[0].Length; i++)
             {
                 Complex32 fourierData = _complexBuffer[i];
-                _spectrum[i] = (float)Math.Sqrt(fourierData.Real * fourierData.Real) + (fourierData.Imaginary * fourierData.Imaginary);
+                _spectrum[0][i] = (float)Math.Sqrt(fourierData.Real * fourierData.Real) + (fourierData.Imaginary * fourierData.Imaginary);
+            }
+
+            // Left channel
+            for (int i = 0; i < dataLeft.Length; i++)
+                _complexBuffer[i] = new Complex32(dataLeft[i], 0);
+
+            Fourier.Forward(_complexBuffer, FourierOptions.NoScaling);
+
+            for (int i = 0; i < _spectrum[1].Length; i++)
+            {
+                Complex32 fourierData = _complexBuffer[i];
+                _spectrum[1][i] = (float)Math.Sqrt(fourierData.Real * fourierData.Real) + (fourierData.Imaginary * fourierData.Imaginary);
+            }
+
+            // Right channel
+            for (int i = 0; i < dataRight.Length; i++)
+                _complexBuffer[i] = new Complex32(dataRight[i], 0);
+
+            Fourier.Forward(_complexBuffer, FourierOptions.NoScaling);
+
+            for (int i = 0; i < _spectrum[2].Length; i++)
+            {
+                Complex32 fourierData = _complexBuffer[i];
+                _spectrum[2][i] = (float)Math.Sqrt(fourierData.Real * fourierData.Real) + (fourierData.Imaginary * fourierData.Imaginary);
             }
         }
 
-        public ISpectrum GetLinearSpectrum(int bands = 64, float minFrequency = -1, float maxFrequency = -1) => new LinearSpectrum(_spectrum, bands, minFrequency, maxFrequency);
+        public ISpectrum GetLinearSpectrum(int bands = 64, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1) => new LinearSpectrum(_spectrum, bands, minFrequency, maxFrequency, audioChannel);
 
-        public ISpectrum GetLogarithmicSpectrum(int bands = 12, float minFrequency = -1, float maxFrequency = -1) => new LogarithmicSpectrum(_spectrum, bands, minFrequency, maxFrequency);
+        public ISpectrum GetLogarithmicSpectrum(int bands = 12, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1) => new LogarithmicSpectrum(_spectrum, bands, minFrequency, maxFrequency, audioChannel);
 
-        public ISpectrum GetGammaSpectrum(int bands = 64, float gamma = 2, float minFrequency = -1, float maxFrequency = -1) => new GammaSpectrum(_spectrum, bands, gamma, minFrequency, maxFrequency);
+        public ISpectrum GetGammaSpectrum(int bands = 64, float gamma = 2, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1) => new GammaSpectrum(_spectrum, bands, gamma, minFrequency, maxFrequency, audioChannel);
 
-        public ISpectrum GetRawSpectrum() => new RawSpectrumProvider(_spectrum);
+        public ISpectrum GetRawSpectrum(int audioChannel = 1) => new RawSpectrumProvider(_spectrum, audioChannel);
 
         #endregion
     }

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/GammaSpectrum.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/GammaSpectrum.cs
@@ -8,12 +8,12 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
     {
         #region Constructors
 
-        public GammaSpectrum(float[] data, int bands, float gamma = 2, float minFrequency = -1, float maxFrequency = -1)
+        public GammaSpectrum(float[][] data, int bands, float gamma = 2, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1)
         {
-            int dataReferenceCount = (data.Length - 1) * 2;
+            int dataReferenceCount = (data[audioChannel - 1].Length - 1) * 2;
 
-            int fromIndex = minFrequency < 0 ? 0 : FrequencyHelper.GetIndexOfFrequency(minFrequency, dataReferenceCount).Clamp(0, data.Length - 1 - bands); // -bands since we need at least enough data to get our bands
-            int toIndex = maxFrequency < 0 ? data.Length - 1 : FrequencyHelper.GetIndexOfFrequency(maxFrequency, dataReferenceCount).Clamp(fromIndex, data.Length - 1);
+            int fromIndex = minFrequency < 0 ? 0 : FrequencyHelper.GetIndexOfFrequency(minFrequency, dataReferenceCount).Clamp(0, data[audioChannel - 1].Length - 1 - bands); // -bands since we need at least enough data to get our bands
+            int toIndex = maxFrequency < 0 ? data[audioChannel - 1].Length - 1 : FrequencyHelper.GetIndexOfFrequency(maxFrequency, dataReferenceCount).Clamp(fromIndex, data[audioChannel - 1].Length - 1);
 
             int usableSourceData = Math.Max(bands, (toIndex - fromIndex) + 1);
 
@@ -25,7 +25,7 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
                 int count = Math.Max(1, (((int)(Math.Pow((i + 1f) / Bands.Length, gamma) * usableSourceData))) - index);
 
                 float[] bandData = new float[count];
-                Array.Copy(data, index, bandData, 0, count);
+                Array.Copy(data[audioChannel - 1], index, bandData, 0, count);
                 Bands[i] = new Band(FrequencyHelper.GetFrequencyOfIndex(index, dataReferenceCount),
                                     FrequencyHelper.GetFrequencyOfIndex(index + count, dataReferenceCount),
                                     bandData);

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/ISpectrumProvider.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/ISpectrumProvider.cs
@@ -2,9 +2,9 @@
 {
     public interface ISpectrumProvider : IAudioProcessor
     {
-        ISpectrum GetLinearSpectrum(int bands = 64, float minFrequency = -1, float maxFrequency = -1);
-        ISpectrum GetLogarithmicSpectrum(int bands = 1, float minFrequency = -1, float maxFrequency = -1);
-        ISpectrum GetGammaSpectrum(int bands = 1, float gamma = 2, float minFrequency = -1, float maxFrequency = -1);
-        ISpectrum GetRawSpectrum();
+        ISpectrum GetLinearSpectrum(int bands = 64, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1);
+        ISpectrum GetLogarithmicSpectrum(int bands = 1, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1);
+        ISpectrum GetGammaSpectrum(int bands = 1, float gamma = 2, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1);
+        ISpectrum GetRawSpectrum(int audioChannel = 1);
     }
 }

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/LinearSpectrum.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/LinearSpectrum.cs
@@ -8,12 +8,12 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
     {
         #region Constructors
 
-        public LinearSpectrum(float[] data, int bands, float minFrequency = -1, float maxFrequency = -1)
+        public LinearSpectrum(float[][] data, int bands, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1)
         {
-            int dataReferenceCount = (data.Length - 1) * 2;
+            int dataReferenceCount = (data[audioChannel - 1].Length - 1) * 2;
 
-            int fromIndex = minFrequency < 0 ? 0 : FrequencyHelper.GetIndexOfFrequency(minFrequency, dataReferenceCount).Clamp(0, data.Length - 1 - bands); // -bands since we need at least enough data to get our bands
-            int toIndex = maxFrequency < 0 ? data.Length - 1 : FrequencyHelper.GetIndexOfFrequency(maxFrequency, dataReferenceCount).Clamp(fromIndex, data.Length - 1);
+            int fromIndex = minFrequency < 0 ? 0 : FrequencyHelper.GetIndexOfFrequency(minFrequency, dataReferenceCount).Clamp(0, data[audioChannel - 1].Length - 1 - bands); // -bands since we need at least enough data to get our bands
+            int toIndex = maxFrequency < 0 ? data[audioChannel - 1].Length - 1 : FrequencyHelper.GetIndexOfFrequency(maxFrequency, dataReferenceCount).Clamp(fromIndex, data[audioChannel - 1].Length - 1);
 
             int usableSourceData = Math.Max(bands, (toIndex - fromIndex) + 1);
 
@@ -29,7 +29,7 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
                 int count = (int)frequencyCounter;
 
                 float[] bandData = new float[count];
-                Array.Copy(data, index, bandData, 0, count);
+                Array.Copy(data[audioChannel - 1], index, bandData, 0, count);
                 Bands[i] = new Band(FrequencyHelper.GetFrequencyOfIndex(index, dataReferenceCount),
                                     FrequencyHelper.GetFrequencyOfIndex(index + count, dataReferenceCount),
                                     bandData);

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/LogarithmicSpectrum.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/LogarithmicSpectrum.cs
@@ -8,12 +8,12 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
     {
         #region Constructors
 
-        public LogarithmicSpectrum(float[] data, int bands, float minFrequency = -1, float maxFrequency = -1)
+        public LogarithmicSpectrum(float[][] data, int bands, float minFrequency = -1, float maxFrequency = -1, int audioChannel = 1)
         {
-            int dataReferenceCount = (data.Length - 1) * 2;
+            int dataReferenceCount = (data[audioChannel - 1].Length - 1) * 2;
 
-            int fromIndex = minFrequency < 0 ? 0 : FrequencyHelper.GetIndexOfFrequency(minFrequency, dataReferenceCount).Clamp(0, data.Length - 1 - bands); // -bands since we need at least enough data to get our bands
-            int toIndex = maxFrequency < 0 ? data.Length - 1 : FrequencyHelper.GetIndexOfFrequency(maxFrequency, dataReferenceCount).Clamp(fromIndex, data.Length - 1);
+            int fromIndex = minFrequency < 0 ? 0 : FrequencyHelper.GetIndexOfFrequency(minFrequency, dataReferenceCount).Clamp(0, data[audioChannel - 1].Length - 1 - bands); // -bands since we need at least enough data to get our bands
+            int toIndex = maxFrequency < 0 ? data[audioChannel - 1].Length - 1 : FrequencyHelper.GetIndexOfFrequency(maxFrequency, dataReferenceCount).Clamp(fromIndex, data[audioChannel - 1].Length - 1);
 
             int usableSourceData = Math.Max(bands, (toIndex - fromIndex) + 1);
 
@@ -29,7 +29,7 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
                 int count = Math.Max(1, ((int)calculation) - index);
 
                 float[] bandData = new float[count];
-                Array.Copy(data, index, bandData, 0, count);
+                Array.Copy(data[audioChannel - 1], index, bandData, 0, count);
                 Bands[i] = new Band(FrequencyHelper.GetFrequencyOfIndex(index, dataReferenceCount),
                                     FrequencyHelper.GetFrequencyOfIndex(index + count, dataReferenceCount),
                                     bandData);

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/RawSpectrumProvider.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioProcessing/Spectrum/RawSpectrumProvider.cs
@@ -6,14 +6,14 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization.AudioProcessing.Spectr
     {
         #region Constructors
 
-        public RawSpectrumProvider(float[] data)
+        public RawSpectrumProvider(float[][] data, int audioChannel)
         {
-            int dataReferenceCount = (data.Length - 1) * 2;
+            int dataReferenceCount = (data[audioChannel - 1].Length - 1) * 2;
 
-            Bands = new Band[data.Length];
+            Bands = new Band[data[audioChannel - 1].Length];
 
             for (int i = 0; i < Bands.Length; i++)
-                Bands[i] = new Band(FrequencyHelper.GetFrequencyOfIndex(i, dataReferenceCount), FrequencyHelper.GetFrequencyOfIndex(i, dataReferenceCount), new[] { data[i] });
+                Bands[i] = new Band(FrequencyHelper.GetFrequencyOfIndex(i, dataReferenceCount), FrequencyHelper.GetFrequencyOfIndex(i, dataReferenceCount), new[] { data[audioChannel - 1][i] });
         }
 
         #endregion

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioVisualizationEffect.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioVisualizationEffect.cs
@@ -75,7 +75,7 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization
 
             RecalculateConfigValues();
 
-            ISpectrum spectrum = GetSpectrum();
+            ISpectrum spectrum = GetSpectrum(GetChannelValue());
             if (spectrum == null) return;
 
             for (int i = 0; i < spectrum.BandCount; i++)
@@ -97,17 +97,28 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization
             }
         }
 
-        private ISpectrum GetSpectrum()
+        private ISpectrum GetSpectrum(int channels)
         {
             return Properties.SpectrumMode.CurrentValue switch
             {
                 SpectrumMode.Gamma => _audioVisualizationService.SpectrumProvider.GetGammaSpectrum(Properties.Bars.CurrentValue, Properties.Gamma.CurrentValue, Properties.MinFrequency.CurrentValue,
-                    Properties.MaxFrequency.CurrentValue),
+                    Properties.MaxFrequency.CurrentValue, channels),
                 SpectrumMode.Logarithmic => _audioVisualizationService.SpectrumProvider.GetLogarithmicSpectrum(Properties.Bars.CurrentValue, Properties.MinFrequency.CurrentValue,
-                    Properties.MaxFrequency.CurrentValue),
+                    Properties.MaxFrequency.CurrentValue, channels),
                 SpectrumMode.Linear => _audioVisualizationService.SpectrumProvider.GetLinearSpectrum(Properties.Bars.CurrentValue, Properties.MinFrequency.CurrentValue,
-                    Properties.MaxFrequency.CurrentValue),
+                    Properties.MaxFrequency.CurrentValue, channels),
                 _ => null
+            };
+        }
+
+        private int GetChannelValue()
+        {
+            return Properties.ChannelMode.CurrentValue switch
+            {
+                ChannelMode.Both => 1,
+                ChannelMode.Left => 2,
+                ChannelMode.Right => 3,
+                _ => 0
             };
         }
 

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioVisualizationEffectProperties.cs
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/AudioVisualizationEffectProperties.cs
@@ -3,6 +3,15 @@ using Artemis.Core;
 
 namespace Artemis.Plugins.LayerEffects.AudioVisualization
 {
+    public enum ChannelMode
+    {
+        [Description("Both")] Both = 1,
+
+        [Description("Left")] Left = 2,
+
+        [Description("Right")] Right = 3
+    }
+
     public enum ValueMode
     {
         [Description("Sum")] Sum = 1,
@@ -24,6 +33,9 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization
     public class AudioVisualizationEffectProperties : LayerPropertyGroup
     {
         #region Properties & Fields
+
+        [PropertyDescription(Description = "The audio channel to generate the visualization from (Both, Left or Right)")]
+        public EnumLayerProperty<ChannelMode> ChannelMode { get; set; }
 
         [PropertyDescription(Description = "The method to calculate the value (Sum, Average or Max)")]
         public EnumLayerProperty<ValueMode> ValueMode { get; set; }
@@ -58,6 +70,7 @@ namespace Artemis.Plugins.LayerEffects.AudioVisualization
 
         protected override void PopulateDefaults()
         {
+            ChannelMode.DefaultValue = AudioVisualization.ChannelMode.Both;
             ValueMode.DefaultValue = AudioVisualization.ValueMode.Sum;
             SpectrumMode.DefaultValue = AudioVisualization.SpectrumMode.Logarithmic;
             Bars.DefaultValue = 48;

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/plugin.json
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.AudioVisualization/plugin.json
@@ -3,7 +3,7 @@
   "Name": "Audio Visualization",
   "Icon": "Music",
   "Description": "Some super awesome audio-visualization.",
-  "Version": "1.0.0.0",
+  "Version": "1.0.0.1",
   "Main": "Artemis.Plugins.LayerEffects.AudioVisualization.dll",
   "AutoEnableFeatures": true
 }


### PR DESCRIPTION
…on plugin

Adds support for selecting just the left or right channel audio when using the AudioVisualization plugin - defaults to using both channels (to maintain compatibility).

Thanks to idi112 for helping debug this code.