### PR TITLE
Add "Disable default profiles creation"

### DIFF
--- a/src/Modules/Artemis.Plugins.Modules.General/GeneralModule.cs
+++ b/src/Modules/Artemis.Plugins.Modules.General/GeneralModule.cs
@@ -13,18 +13,23 @@ namespace Artemis.Plugins.Modules.General
     public class GeneralModule : Module<GeneralDataModel>
     {
         private readonly PluginSetting<bool> _enableActiveWindow;
+        private readonly PluginSetting<bool> _disableDefaultProfilesCreation;
         private readonly IColorQuantizerService _quantizerService;
 
         public GeneralModule(IColorQuantizerService quantizerService, PluginSettings settings)
         {
             _quantizerService = quantizerService;
             _enableActiveWindow = settings.GetSetting("EnableActiveWindow", true);
+            _disableDefaultProfilesCreation = settings.GetSetting("DisableDefaultProfilesCreation", false);
 
             DisplayName = "General";
             DisplayIcon = "Images/bow.svg";
 
-            AddDefaultProfile(DefaultCategoryName.General, "Profiles/rainbow.json");
-            AddDefaultProfile(DefaultCategoryName.General, "Profiles/noise.json");
+            if (!_disableDefaultProfilesCreation.Value)
+            {
+                AddDefaultProfile(DefaultCategoryName.General, "Profiles/rainbow.json");
+                AddDefaultProfile(DefaultCategoryName.General, "Profiles/noise.json");
+            }
         }
 
         public override void Enable()

--- a/src/Modules/Artemis.Plugins.Modules.General/ViewModels/GeneralModuleConfigurationViewModel.cs
+++ b/src/Modules/Artemis.Plugins.Modules.General/ViewModels/GeneralModuleConfigurationViewModel.cs
@@ -8,19 +8,23 @@ namespace Artemis.Plugins.Modules.General.ViewModels
         public GeneralModuleConfigurationViewModel(Plugin plugin, PluginSettings settings) : base(plugin)
         {
             EnableActiveWindow = settings.GetSetting("EnableActiveWindow", true);
+            DisableDefaultProfilesCreation = settings.GetSetting("DisableDefaultProfilesCreation", true);
         }
 
         public PluginSetting<bool> EnableActiveWindow { get; set; }
+        public PluginSetting<bool> DisableDefaultProfilesCreation { get; set; }
 
         protected override void OnInitialActivate()
         {
             EnableActiveWindow.AutoSave = true;
+            DisableDefaultProfilesCreation.AutoSave = true;
             base.OnInitialActivate();
         }
 
         protected override void OnClose()
         {
             EnableActiveWindow.AutoSave = false;
+            DisableDefaultProfilesCreation.AutoSave = false;
             base.OnClose();
         }
     }

--- a/src/Modules/Artemis.Plugins.Modules.General/Views/GeneralModuleConfigurationView.xaml
+++ b/src/Modules/Artemis.Plugins.Modules.General/Views/GeneralModuleConfigurationView.xaml
@@ -27,7 +27,7 @@
                                 <TextBlock Style="{StaticResource MaterialDesignTextBlock}">Monitor active window</TextBlock>
                                 <TextBlock Style="{StaticResource MaterialDesignTextBlock}" Foreground="{DynamicResource MaterialDesignNavigationItemSubheader}" TextWrapping="Wrap">
                                         Enables or disables the active window data model property. <LineBreak />
-                                        Data is not stored and is never shared. Disabling this can increase performance,<LineBreak />
+                                        Data is not stored and is never shared. Disabling this can increase performance.<LineBreak />
                                 </TextBlock>
                             </StackPanel>
                             <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center">

--- a/src/Modules/Artemis.Plugins.Modules.General/Views/GeneralModuleConfigurationView.xaml
+++ b/src/Modules/Artemis.Plugins.Modules.General/Views/GeneralModuleConfigurationView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Artemis.Plugins.Modules.General.Views.GeneralModuleConfigurationView"
+<UserControl x:Class="Artemis.Plugins.Modules.General.Views.GeneralModuleConfigurationView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -27,12 +27,21 @@
                                 <TextBlock Style="{StaticResource MaterialDesignTextBlock}">Monitor active window</TextBlock>
                                 <TextBlock Style="{StaticResource MaterialDesignTextBlock}" Foreground="{DynamicResource MaterialDesignNavigationItemSubheader}" TextWrapping="Wrap">
                                         Enables or disables the active window data model property. <LineBreak />
-                                        Data is not stored and is never shared. Disabling this can increase performance
+                                        Data is not stored and is never shared. Disabling this can increase performance,<LineBreak />
                                 </TextBlock>
                             </StackPanel>
                             <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center">
                             <ToggleButton Style="{StaticResource MaterialDesignSwitchToggleButton}" IsChecked="{Binding EnableActiveWindow.Value}" />
                         </StackPanel>
+                        <StackPanel Grid.Row="1" Grid.Column="0">
+                            <TextBlock Style="{StaticResource MaterialDesignTextBlock}">Disable default profiles creation</TextBlock>
+                            <TextBlock Style="{StaticResource MaterialDesignTextBlock}" Foreground="{DynamicResource MaterialDesignNavigationItemSubheader}" TextWrapping="Wrap">
+                                            Enables or disables the automatic creation of "General" category and default profiles.<LineBreak />
+                            </TextBlock>
+                        </StackPanel>
+                        <StackPanel Grid.Row="1" Grid.Column="1" VerticalAlignment="Center">
+                            <ToggleButton Style="{StaticResource MaterialDesignSwitchToggleButton}" IsChecked="{Binding DisableDefaultProfilesCreation.Value}" />
+                        </StackPanel>                           
                         </Grid>
                     </StackPanel>
                 </materialDesign:Card>


### PR DESCRIPTION
This PR adds a new option to the General Module options to disable default profiles creation.

This option is disabled by default to allow users to get default profiles on new installs.

![image](https://user-images.githubusercontent.com/972765/120897046-5abc9d00-c5f2-11eb-8d68-4bdd1d90bb4a.png)

 