### PR TITLE
Handle no device initialization

### DIFF
--- a/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
+++ b/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
@@ -33,6 +33,19 @@ namespace Artemis.Plugins.Audio.DataModelExpansion.DataModels
         public DataModelEvent VolumeChanged { get; set; } = new DataModelEvent();
         public ChannelsDataModel Channels { get; set; } = new ChannelsDataModel();
 
+        public void Reset()
+        {
+            DefaultDeviceName = "No device detected";
+            ChannelCount = 0;
+            Volume = 0;
+            VolumeNormalized = 0;
+            Muted = false;
+            PeakVolume = 0;
+            PeakVolumeNormalized = 0;
+            PeakVolumeRelative = 0;
+            PeakVolumeRelativeNormalized = 0;
+            DeviceState = DeviceState.NotPresent;
+        }
     }
 
     public class ChannelsDataModel : DataModel { }

--- a/src/Collections/Artemis.Plugins.Audio/LayerEffects/AudioCapture/NAudioAudioInput.cs
+++ b/src/Collections/Artemis.Plugins.Audio/LayerEffects/AudioCapture/NAudioAudioInput.cs
@@ -42,8 +42,13 @@ namespace Artemis.Plugins.Audio.LayerEffects.AudioCapture
         public void Initialize()
         {
             _endpoint = _naudioDeviceEnumerationService.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-            _capture = _useCustomWasapiCapture 
-                ? CustomWasapiLoopbackCapture.CreateCustomWasapiLoopbackCapture(_endpoint, false, _logger) 
+            
+            // Don't initialize if there is no available device.
+            if (_endpoint == null)
+                return;
+
+            _capture = _useCustomWasapiCapture
+                ? CustomWasapiLoopbackCapture.CreateCustomWasapiLoopbackCapture(_endpoint, false, _logger)
                 : new WasapiLoopbackCapture();
             _capture.RecordingStopped += CaptureOnRecordingStopped;
 

--- a/src/Collections/Artemis.Plugins.Audio/Services/NAudioDeviceEnumerationService.cs
+++ b/src/Collections/Artemis.Plugins.Audio/Services/NAudioDeviceEnumerationService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using Artemis.Core.Services;
 using Artemis.Plugins.Audio.Interfaces;
 using NAudio.CoreAudioApi;
@@ -59,6 +60,11 @@ namespace Artemis.Plugins.Audio.Services
             catch (AggregateException ea)
             {
                 _logger.Error("AggregateException on GetCurrentDevice() " + ea);
+            }
+            catch (COMException ea)
+            {
+                if (ea.ErrorCode == -2147023728) // 0x80070490 No audio defive found.
+                    _logger.Verbose("No audio device found to be returned as current playback device. Some plugins may stop working.");
             }
             catch (NullReferenceException noe)
             {


### PR DESCRIPTION
Handle COM+ exception when there is no device available to get better logging.
Add null device check to Audio Visualizer Layer.
Add default values to Playback volume data model when there is no connected device.
Better handle of disappearing devices in playback volume plugin.
