### PR TITLE
Fix Typo and add OneKey mode

### DIFF
--- a/src/Collections/Artemis.Plugins.Input/LayerBrush/Keypress/Effects/KeyPressRipple.cs
+++ b/src/Collections/Artemis.Plugins.Input/LayerBrush/Keypress/Effects/KeyPressRipple.cs
@@ -120,14 +120,14 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress.Effects
             UpdatePaint();
         }
 
-        public bool AllowDuplicates => _brush.Properties.RippleBehivor == RippleBehivor.CreateNewRipple;
+        public bool AllowDuplicates => _brush.Properties.RippleBehavior == RippleBehavior.CreateNewRipple;
         public bool Finished => Size < 0f;
         public ArtemisLed Led { get; }
         public SKPoint Position { get; set; }
 
         public void Update(double deltaTime)
         {
-            if (_brush.Properties.RippleBehivor.CurrentValue == RippleBehivor.ContinuousWhileKeyPressed)
+            if (_brush.Properties.RippleBehavior.CurrentValue == RippleBehavior.ContinuousWhileKeyPressed)
                 UpdateContinuous(deltaTime);
             else
                 UpdateOne(deltaTime);
@@ -159,13 +159,13 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress.Effects
         public void Respawn()
         {
             Expand = true;
-            if (_brush.Properties.RippleBehivor == RippleBehivor.ResetCurrentRipple)
+            if (_brush.Properties.RippleBehavior == RippleBehavior.ResetCurrentRipple)
                 Size = 0;
         }
 
         public void Despawn()
         {
-            if (_brush.Properties.RippleBehivor.CurrentValue == RippleBehivor.ContinuousWhileKeyPressed)
+            if (_brush.Properties.RippleBehavior.CurrentValue == RippleBehavior.ContinuousWhileKeyPressed)
                 Expand = false;
         }
     }

--- a/src/Collections/Artemis.Plugins.Input/LayerBrush/Keypress/KeypressBrush.cs
+++ b/src/Collections/Artemis.Plugins.Input/LayerBrush/Keypress/KeypressBrush.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Artemis.Core;
 using Artemis.Core.LayerBrushes;
+using Artemis.Core.Modules;
 using Artemis.Core.Services;
 using Artemis.Plugins.Input.LayerBrush.Keypress.Effects;
 using SkiaSharp;
@@ -81,8 +82,8 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
                             _effects.Add(new KeypressWhilePressed(this, led, relativeLedPosition));
                             break;
                         case AnimationType.Ripple:
-                             _effects.Add(new KeypressRipple(this, led, relativeLedPosition));
-                             break;
+                            _effects.Add(new KeypressRipple(this, led, relativeLedPosition));
+                            break;
                         case AnimationType.Echo:
                             _effects.Add(new KeyPressEcho(this, led, relativeLedPosition));
                             break;
@@ -108,6 +109,9 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
         private void InputServiceOnKeyboardKeyDown(object sender, ArtemisKeyboardKeyEventArgs e)
         {
             if (e.Led == null)
+                return;
+
+            if (e.Key != Properties.Key.CurrentValue && Properties.OneKeyMode.CurrentValue)
                 return;
 
             // Get the position of the LED relative to the layer

--- a/src/Collections/Artemis.Plugins.Input/LayerBrush/Keypress/KeypressBrushProperties.cs
+++ b/src/Collections/Artemis.Plugins.Input/LayerBrush/Keypress/KeypressBrushProperties.cs
@@ -1,4 +1,5 @@
 using Artemis.Core;
+using Artemis.Core.Services;
 using SkiaSharp;
 
 namespace Artemis.Plugins.Input.LayerBrush.Keypress
@@ -16,6 +17,11 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
 
         public SKColorLayerProperty Color { get; set; }
 
+        [PropertyDescription(Description = "This option limit the input events to one single key.")]
+        public BoolLayerProperty OneKeyMode { get; set; }
+        [PropertyDescription(Description = "Key used to trigger ripples when using Enable One Key mode is enabled.")]
+        public EnumLayerProperty<KeyboardKey> Key { get; set; }
+
         // Echo
 
         [PropertyDescription(Description = "If enabled, the echo fades out after you release the key.")]
@@ -27,7 +33,7 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
         // Ripple
 
         [PropertyDescription(Description = "Set how ripple will respond to a keypress.")]
-        public EnumLayerProperty<RippleBehivor> RippleBehivor { get; set; }
+        public EnumLayerProperty<RippleBehavior> RippleBehavior { get; set; }
 
         [PropertyDescription(Description = "Fade away ripple effect mode.")]
         public EnumLayerProperty<RippleFadeOutMode> RippleFadeAway { get; set; }
@@ -52,12 +58,12 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
         [PropertyDescription(Description = "Expand speed of the ripple.")]
         public FloatLayerProperty CircleGrowthSpeed { get; set; }
 
-
-
         protected override void PopulateDefaults()
         {
             Color.DefaultValue = new SKColor(255, 0, 0);
             Colors.DefaultValue = ColorGradient.GetUnicornBarf();
+            OneKeyMode.DefaultValue = false;
+            Key.DefaultValue = KeyboardKey.None;
 
             //Echo
             FadeEcho.DefaultValue = true;
@@ -67,7 +73,7 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
             RippleWidth.DefaultValue = 40;
             RippleSize.DefaultValue = 200;
             RippleGrowthSpeed.DefaultValue = 300;
-            RippleBehivor.DefaultValue = Keypress.RippleBehivor.OneAtATime;
+            RippleBehavior.DefaultValue = Keypress.RippleBehavior.OneAtATime;
             RippleFadeAway.DefaultValue = RippleFadeOutMode.Linear;
             RippleTrail.DefaultValue = true;
 
@@ -81,6 +87,7 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
             // Shared
             Colors.IsVisibleWhen(ColorMode, c => c.CurrentValue == ColorType.Gradient || c.CurrentValue == ColorType.ColorChange);
             Color.IsVisibleWhen(ColorMode, c => c.CurrentValue == ColorType.Solid);
+            Key.IsVisibleWhen(OneKeyMode, c => c.CurrentValue);
 
             // Echo
             FadeEcho.IsVisibleWhen(Animation, a => a.CurrentValue == AnimationType.Echo);
@@ -91,7 +98,7 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
             RippleFadeAway.IsVisibleWhen(Animation, a => a.CurrentValue == AnimationType.Ripple);
             RippleSize.IsVisibleWhen(Animation, a => a.CurrentValue == AnimationType.Ripple);
             RippleGrowthSpeed.IsVisibleWhen(Animation, a => a.CurrentValue == AnimationType.Ripple);
-            RippleBehivor.IsVisibleWhen(Animation, a => a.CurrentValue == AnimationType.Ripple);
+            RippleBehavior.IsVisibleWhen(Animation, a => a.CurrentValue == AnimationType.Ripple);
             RippleTrail.IsVisibleWhen(Animation, a => a.CurrentValue == AnimationType.Ripple);
 
             //Circle
@@ -127,7 +134,7 @@ namespace Artemis.Plugins.Input.LayerBrush.Keypress
         Ripple = 1,
         Echo = 2
     }
-    public enum RippleBehivor
+    public enum RippleBehavior
     {
         OneAtATime = 0,
         ResetCurrentRipple = 1,


### PR DESCRIPTION
I think One Key Mode should be a multi select option but don't know how to do that (It requires Artemis Changes?). One key should work in the meanwhile for users asking for specific ripple colors for specific keys.