### PR TITLE
Fixed Ambilight position calculation

### DIFF
--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/AmbilightLayerBrush.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/AmbilightLayerBrush.cs
@@ -102,8 +102,8 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight
                 // Stick to a valid region within the display
                 int width = Math.Min(_display.Value.Width, props.Width);
                 int height = Math.Min(_display.Value.Height, props.Height);
-                int x = Math.Min(width - 1, props.X);
-                int y = Math.Min(height - 1, props.Y);
+                int x = Math.Min(_display.Value.Width - width, props.X);
+                int y = Math.Min(_display.Value.Height - height, props.Y);
                 _captureZone = _screenCaptureService.GetScreenCapture(_display.Value).RegisterCaptureZone(x, y, width, height, props.DownscaleLevel);
                 _captureZone.AutoUpdate = false; //TODO DarthAffe 09.04.2021: config?
                 _captureZone.BlackBars.Threshold = props.BlackBarDetectionThreshold;


### PR DESCRIPTION
The calculation for the current ambilight position is incorrect whenever `x > width && x < _display.Value.Width`. This changes the calculation to take the difference between the display's width and the ambilight width against the `x` property. Same changes apply for `y` and height as well

ex: `displayWidth == 10`, `props.x == 5`, `width == 2`

Current calculation: `x = min(2-1, 5) = 1`
New calculation: `x = min(10-2, 5) = 5`

We know the given x is valid as props.x + width < displayWidth ( 5+2 < 10 ). We should only change the given value if `x + width > displayWidth`.