### PR TITLE
Add missing lock and fix with <= 0 exception

### DIFF
--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/ScreenCapture/AmbilightScreenCaptureService.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/ScreenCapture/AmbilightScreenCaptureService.cs
@@ -39,10 +39,13 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight.ScreenCapture
 
         public IScreenCapture GetScreenCapture(Display display)
         {
-            if (!_screenCaptures.TryGetValue(display, out IScreenCapture screenCapture))
-                _screenCaptures.Add(display, screenCapture = new AmbilightScreenCapture(_screenCaptureService.GetScreenCapture(display)));
+            lock (_screenCaptures)
+            {
+                if (!_screenCaptures.TryGetValue(display, out IScreenCapture screenCapture))
+                    _screenCaptures.Add(display, screenCapture = new AmbilightScreenCapture(_screenCaptureService.GetScreenCapture(display)));
 
-            return screenCapture;
+                return screenCapture;
+            }
         }
 
         public void Dispose()

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/UI/CapturePropertiesViewModel.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/UI/CapturePropertiesViewModel.cs
@@ -35,7 +35,6 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight.UI
         private readonly Timer _displayPreviewTimer = new(500) {AutoReset = true};
         private readonly Timer _selectionPreviewTimer = new(33) {AutoReset = true};
         private bool _preventPreviewCreation;
-        private bool _closing;
         private DisplayPreview _selectedDisplay;
 
         public int X
@@ -87,7 +86,7 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight.UI
             get => _selectedDisplay;
             set
             {
-                if (_closing) return; // Don't update display and region if dialog is being closed to avoid 0 values
+                if (!IsActive) return; // Don't update display and region if dialog is being closed to avoid 0 values
                 if (!SetAndNotify(ref _selectedDisplay, value)) return;
                 if (X + Width > (value?.Display.Width ?? 0) || Y + Height > (value?.Display.Height ?? 0) || Width == 0 || Height == 0)
                 {
@@ -306,7 +305,6 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight.UI
         protected override void OnClose()
         {
             _preventPreviewCreation = true;
-            _closing = true;
 
             _displayPreviewTimer.Stop();
             _displayPreviewTimer.Dispose();

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/UI/CapturePropertiesViewModel.cs
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/UI/CapturePropertiesViewModel.cs
@@ -35,6 +35,7 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight.UI
         private readonly Timer _displayPreviewTimer = new(500) {AutoReset = true};
         private readonly Timer _selectionPreviewTimer = new(33) {AutoReset = true};
         private bool _preventPreviewCreation;
+        private bool _closing;
         private DisplayPreview _selectedDisplay;
 
         public int X
@@ -86,6 +87,7 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight.UI
             get => _selectedDisplay;
             set
             {
+                if (_closing) return; // Don't update display and region if dialog is being closed to avoid 0 values
                 if (!SetAndNotify(ref _selectedDisplay, value)) return;
                 if (X + Width > (value?.Display.Width ?? 0) || Y + Height > (value?.Display.Height ?? 0) || Width == 0 || Height == 0)
                 {
@@ -304,6 +306,7 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight.UI
         protected override void OnClose()
         {
             _preventPreviewCreation = true;
+            _closing = true;
 
             _displayPreviewTimer.Stop();
             _displayPreviewTimer.Dispose();


### PR DESCRIPTION
Fix: System.ArgumentException: An item with the same key has already been added. Key: ScreenCapture.NET.Display when there are multiple ambilight layers

Complete exception:

System.ArgumentException: An item with the same key has already been added. Key: ScreenCapture.NET.Display
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at ScreenCapture.NET.DX11ScreenCaptureService.GetScreenCapture(Display display)
   at Artemis.Plugins.LayerBrushes.Ambilight.ScreenCapture.AmbilightScreenCaptureService.GetScreenCapture(Display display) in D:\Repos\Artemis.Plugins.Artemis\src\LayerBrushes\Artemis.Plugins.LayerBrushes.Ambilight\ScreenCapture\AmbilightScreenCaptureService.cs:line 45
   at Artemis.Plugins.LayerBrushes.Ambilight.AmbilightLayerBrush.RecreateCaptureZone() in D:\Repos\Artemis.Plugins.Artemis\src\LayerBrushes\Artemis.Plugins.LayerBrushes.Ambilight\AmbilightLayerBrush.cs:line 107
   at Artemis.Plugins.LayerBrushes.Ambilight.AmbilightLayerBrush.EnableLayerBrush() in D:\Repos\Artemis.Plugins.Artemis\src\LayerBrushes\Artemis.Plugins.LayerBrushes.Ambilight\AmbilightLayerBrush.cs:line 67
   at Artemis.Core.LayerBrushes.PropertiesLayerBrush`1.InitializeProperties() in D:\Repos\Artemis\src\Artemis.Core\Plugins\LayerBrushes\Internal\PropertiesLayerBrush.cs:line 43
   at Artemis.Core.BreakableModel.TryOrBreak(Action action, String breakMessage) in D:\Repos\Artemis\src\Artemis.Core\Models\BreakableModel.cs:line 50

![Captura de pantalla 2021-07-15 004000](https://user-images.githubusercontent.com/972765/125729966-20e69cef-e2cb-461c-ab2f-acce9c437e2c.png)

Tested with up to 5 layers at the same time

Steps to reproduce bug and text the fix:

1.- Add two or more ambilight layers to a profile.
2.- Open profile editor.
3.- Select the profile with two or more ambilight layers.
4.- One of the layers (should be the second) will fail to load.

After the fix all layers should work 

![image](https://user-images.githubusercontent.com/972765/125731730-2b17bff8-8bc3-4c0a-b8a4-22170842266c.png)
