### PR TITLE
Add per session peak volume

### DIFF
--- a/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
+++ b/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
@@ -56,7 +56,6 @@ namespace Artemis.Plugins.Audio.DataModelExpansion.DataModels
 
     public class SessionDataModel : DataModel
     {
-        public uint Id { get; set; }
         public string Name { get; set; }
         public AudioSessionState? State { get; set; }
         public float PeakVolume { get; set; }

--- a/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
+++ b/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
@@ -56,12 +56,11 @@ namespace Artemis.Plugins.Audio.DataModelExpansion.DataModels
 
     public class SessionDataModel : DataModel
     {
-        public string Id { get; set; }
+        public uint Id { get; set; }
         public string Name { get; set; }
         public AudioSessionState? State { get; set; }
         public float PeakVolume { get; set; }
         public float PeakVolumeNormalized { get; set; }
-        public string debugData { get; set; }
     }
 
     public class ChannelDataModel : DataModel

--- a/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
+++ b/src/Collections/Artemis.Plugins.Audio/DataModelExpansion/DataModels/PlaybackVolumeDataModel.cs
@@ -2,12 +2,13 @@
 using Artemis.Core;
 using Artemis.Core.Modules;
 using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
 
 namespace Artemis.Plugins.Audio.DataModelExpansion.DataModels
 {
     public class PlaybackVolumeDataModel : DataModel
     {
-        [DataModelProperty(Description ="Name of the current playback device.")]
+        [DataModelProperty(Description = "Name of the current playback device.")]
         public string DefaultDeviceName { get; set; }
         [DataModelProperty(Description = "Channel count of the the current playback device.")]
         public int ChannelCount { get; set; }
@@ -32,6 +33,7 @@ namespace Artemis.Plugins.Audio.DataModelExpansion.DataModels
         [DataModelProperty(Description = "Event triggered when current playback device master volume is changed.")]
         public DataModelEvent VolumeChanged { get; set; } = new DataModelEvent();
         public ChannelsDataModel Channels { get; set; } = new ChannelsDataModel();
+        public SessionsDataModel Sessions { get; set; } = new SessionsDataModel();
 
         public void Reset()
         {
@@ -49,6 +51,19 @@ namespace Artemis.Plugins.Audio.DataModelExpansion.DataModels
     }
 
     public class ChannelsDataModel : DataModel { }
+
+    public class SessionsDataModel : DataModel { }
+
+    public class SessionDataModel : DataModel
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public AudioSessionState? State { get; set; }
+        public float PeakVolume { get; set; }
+        public float PeakVolumeNormalized { get; set; }
+        public string debugData { get; set; }
+    }
+
     public class ChannelDataModel : DataModel
     {
         public int ChannelIndex { get; set; }


### PR DESCRIPTION
This PR add a collection of applications and their audio session real time peak volume.

To make this works, i had to create a settings that holds used data sessions to create (or re-create an empty/volume 0 session datamodel) them at plugin startup otherwise conditions using these dynamic datamodels will fail because these session datamodels don't exists at the moment Artemis is loaded (Don't know if this is an Artemis bug or the intended behavior).

