### PR TITLE
WIP: Added Logitech prerequisites

### DIFF
--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Bootstrapper.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Bootstrapper.cs
@@ -1,4 +1,4 @@
-﻿using Artemis.Core;
+using Artemis.Core;
 using Artemis.Plugins.Devices.Logitech.Prerequisites;
 
 namespace Artemis.Plugins.Devices.Logitech
@@ -8,6 +8,7 @@ namespace Artemis.Plugins.Devices.Logitech
         public override void OnPluginLoaded(Plugin plugin)
         {
             AddPluginPrerequisite(new VcRedistPrerequisite(plugin));
+            AddPluginPrerequisite(new LgsOrGhubPrerequisite(plugin));
         }
     }
 }

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Bootstrapper.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Bootstrapper.cs
@@ -1,4 +1,4 @@
-using Artemis.Core;
+﻿using Artemis.Core;
 using Artemis.Plugins.Devices.Logitech.Prerequisites;
 
 namespace Artemis.Plugins.Devices.Logitech
@@ -9,6 +9,7 @@ namespace Artemis.Plugins.Devices.Logitech
         {
             AddPluginPrerequisite(new VcRedistPrerequisite(plugin));
             AddPluginPrerequisite(new LgsOrGhubPrerequisite(plugin));
+            AddPluginPrerequisite(new AuroraWrapperPatchPrerequisite());
         }
     }
 }

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/AuroraWrapperPatchPrerequisite.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/AuroraWrapperPatchPrerequisite.cs
@@ -1,0 +1,30 @@
+﻿using Artemis.Core;
+using Microsoft.Win32;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace Artemis.Plugins.Devices.Logitech.Prerequisites
+{
+    /// <summary>
+    /// Checks for presence of Aurora's Wrapper patch dll in the system directory
+    /// </summary>
+    internal class AuroraWrapperPatchPrerequisite : PluginPrerequisite
+    {
+        public override string Name => "Logitech Dll Check";
+
+        public override string Description => "Checks for presence of the backup logitech dll placed by Aurora";
+
+        public override List<PluginPrerequisiteAction> InstallActions { get; } = new()
+        {
+            new RunInlinePowerShellAction("Copy backup dll over", $"Move-Item -Path \"{AURORA_BACKUP_PATH}\" -Destination \"{AURORA_WRAPPER_PATH}\"" , true)
+        };
+
+        public override List<PluginPrerequisiteAction> UninstallActions { get; } = new();
+
+        public override bool IsMet() => !File.Exists(AURORA_BACKUP_PATH);
+
+        private const string AURORA_WRAPPER_PATH = "C:\\Program Files\\Logitech Gaming Software\\SDK\\LED\\x64\\LogitechLed.dll";
+        private const string AURORA_BACKUP_PATH = "C:\\Program Files\\Logitech Gaming Software\\SDK\\LED\\x64\\LogitechLed.dll.aurora_backup";
+    }
+}

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/AuroraWrapperPatchPrerequisite.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/AuroraWrapperPatchPrerequisite.cs
@@ -1,7 +1,5 @@
 ﻿using Artemis.Core;
-using Microsoft.Win32;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 
 namespace Artemis.Plugins.Devices.Logitech.Prerequisites
@@ -11,20 +9,20 @@ namespace Artemis.Plugins.Devices.Logitech.Prerequisites
     /// </summary>
     internal class AuroraWrapperPatchPrerequisite : PluginPrerequisite
     {
-        public override string Name => "Logitech Dll Check";
+        public override string Name => "Logitech DLL Check";
 
-        public override string Description => "Checks for presence of the backup logitech dll placed by Aurora";
+        public override string Description => "Checks for presence of the backup Logitech DLL placed by Aurora";
 
         public override List<PluginPrerequisiteAction> InstallActions { get; } = new()
         {
-            new RunInlinePowerShellAction("Copy backup dll over", $"Move-Item -Path \"{AURORA_BACKUP_PATH}\" -Destination \"{AURORA_WRAPPER_PATH}\"" , true)
+            new RunInlinePowerShellAction("Copy backup DLL over", $"Move-Item -Path \"{AURORA_BACKUP_PATH}\" -Destination \"{AURORA_WRAPPER_PATH}\"" , true)
         };
 
         public override List<PluginPrerequisiteAction> UninstallActions { get; } = new();
 
         public override bool IsMet() => !File.Exists(AURORA_BACKUP_PATH);
 
-        private const string AURORA_WRAPPER_PATH = "C:\\Program Files\\Logitech Gaming Software\\SDK\\LED\\x64\\LogitechLed.dll";
-        private const string AURORA_BACKUP_PATH = "C:\\Program Files\\Logitech Gaming Software\\SDK\\LED\\x64\\LogitechLed.dll.aurora_backup";
+        private const string AURORA_WRAPPER_PATH = @"C:\Program Files\Logitech Gaming Software\SDK\LED\x64\LogitechLed.dll";
+        private const string AURORA_BACKUP_PATH = @"C:\Program Files\Logitech Gaming Software\SDK\LED\x64\LogitechLed.dll.aurora_backup";
     }
 }

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LgsOrGhubPrerequisite.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LgsOrGhubPrerequisite.cs
@@ -1,0 +1,33 @@
+﻿using Artemis.Core;
+using System.Collections.Generic;
+
+namespace Artemis.Plugins.Devices.Logitech.Prerequisites
+{
+    internal class LgsOrGhubPrerequisite : PluginPrerequisite
+    {
+        private readonly Plugin _plugin;
+
+        public LgsOrGhubPrerequisite(Plugin plugin)
+        {
+            _plugin = plugin;
+        }
+
+        public override string Name => "Required Logitech software";
+
+        public override string Description => "Checks if the required Logitech software is installed on the system.";
+
+        public override List<PluginPrerequisiteAction> InstallActions => new()
+        {
+            new DownloadFileAction("Download LGHUB installer", "https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe", _plugin.ResolveRelativePath("lghub_installer.exe")),
+            new ExecuteFileAction("Install LGHUB", _plugin.ResolveRelativePath("lghub_installer.exe"), null, true, true),
+            new DeleteFileAction("Delete LGHUB installer", _plugin.ResolveRelativePath("lghub_installer.exe")),
+        };
+
+        public override List<PluginPrerequisiteAction> UninstallActions => new();
+
+        public override bool IsMet()
+        {
+            return LogitechSoftwareChecker.IsLghubInstalled() || LogitechSoftwareChecker.IsLgsInstalled();
+        }
+    }
+}

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LgsOrGhubPrerequisite.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LgsOrGhubPrerequisite.cs
@@ -10,20 +10,24 @@ namespace Artemis.Plugins.Devices.Logitech.Prerequisites
         public LgsOrGhubPrerequisite(Plugin plugin)
         {
             _plugin = plugin;
+
+            InstallActions = new()
+            {
+                new DownloadFileAction("Download LGHUB installer", "https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe", _plugin.ResolveRelativePath("lghub_installer.exe")),
+                new ExecuteFileAction("Install LGHUB", _plugin.ResolveRelativePath("lghub_installer.exe"), null, true, true),
+                new DeleteFileAction("Delete LGHUB installer", _plugin.ResolveRelativePath("lghub_installer.exe")),
+            };
+
+            UninstallActions = new();
         }
 
         public override string Name => "Required Logitech software";
 
         public override string Description => "Checks if the required Logitech software is installed on the system.";
 
-        public override List<PluginPrerequisiteAction> InstallActions => new()
-        {
-            new DownloadFileAction("Download LGHUB installer", "https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe", _plugin.ResolveRelativePath("lghub_installer.exe")),
-            new ExecuteFileAction("Install LGHUB", _plugin.ResolveRelativePath("lghub_installer.exe"), null, true, true),
-            new DeleteFileAction("Delete LGHUB installer", _plugin.ResolveRelativePath("lghub_installer.exe")),
-        };
+        public override List<PluginPrerequisiteAction> InstallActions { get; }
 
-        public override List<PluginPrerequisiteAction> UninstallActions => new();
+        public override List<PluginPrerequisiteAction> UninstallActions { get; }
 
         public override bool IsMet()
         {

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LogitechSoftwareChecker.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LogitechSoftwareChecker.cs
@@ -4,21 +4,20 @@ namespace Artemis.Plugins.Devices.Logitech.Prerequisites
 {
     internal static class LogitechSoftwareChecker
     {
-        internal static bool IsLgsInstalled()
+        internal static bool IsLgsInstalled() => DoesRegistrySubKeyExist(REGISTRY_LGS);
+
+        internal static bool IsLghubInstalled() => DoesRegistrySubKeyExist(REGISTRY_LGHUB);
+
+        internal static bool DoesRegistrySubKeyExist(string subkey)
         {
             using RegistryKey installedPrograms = Registry.LocalMachine.OpenSubKey(REGISTRY_INSTALLED_SOFTWARE);
 
-            return installedPrograms.OpenSubKey(REGISTRY_LGS) != null;
+            using RegistryKey subKey = installedPrograms.OpenSubKey(subkey);
+
+            return subkey != null;
         }
 
-        internal static bool IsLghubInstalled()
-        {
-            using RegistryKey installedPrograms = Registry.LocalMachine.OpenSubKey(REGISTRY_INSTALLED_SOFTWARE);
-
-            return installedPrograms.OpenSubKey(REGISTRY_LGHUB) != null;
-        }
-
-        private const string REGISTRY_INSTALLED_SOFTWARE = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+        private const string REGISTRY_INSTALLED_SOFTWARE = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
         private const string REGISTRY_LGHUB = "{521c89be-637f-4274-a840-baaf7460c2b2}";
         private const string REGISTRY_LGS = "Logitech Gaming Software";
     }

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LogitechSoftwareChecker.cs
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Prerequisites/LogitechSoftwareChecker.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Win32;
+
+namespace Artemis.Plugins.Devices.Logitech.Prerequisites
+{
+    internal static class LogitechSoftwareChecker
+    {
+        internal static bool IsLgsInstalled()
+        {
+            using RegistryKey installedPrograms = Registry.LocalMachine.OpenSubKey(REGISTRY_INSTALLED_SOFTWARE);
+
+            return installedPrograms.OpenSubKey(REGISTRY_LGS) != null;
+        }
+
+        internal static bool IsLghubInstalled()
+        {
+            using RegistryKey installedPrograms = Registry.LocalMachine.OpenSubKey(REGISTRY_INSTALLED_SOFTWARE);
+
+            return installedPrograms.OpenSubKey(REGISTRY_LGHUB) != null;
+        }
+
+        private const string REGISTRY_INSTALLED_SOFTWARE = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
+        private const string REGISTRY_LGHUB = "{521c89be-637f-4274-a840-baaf7460c2b2}";
+        private const string REGISTRY_LGS = "Logitech Gaming Software";
+    }
+}


### PR DESCRIPTION
Some things to consider:
* The registry keys might not be present if the user kept their GHUB install from another windows installation on another drive, for example. Do we need this prerequisite or is it too much?
* Is the Aurora un-patch robust enough?
* Does the GHUB installer cleanup task execute after the installation is complete? I did not test this.

Submitting as a PR because hacktoberfest :)