### PR TITLE
Refactor plugin .csproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ Due to the volatine nature of the project right now, there is no documentation y
 
 #### Want to build? Follow these instructions
 1. Create a central folder like ```C:\Repos```
-2. Clone RGB.NET's development branch into ```<central folder>\RGB.NET```
-3. Clone Artemis into  ```<central folder>\Artemis```
-5. Open ```<central folder>\RGB.NET\RGB.NET.sln``` and build with the default config
-4. Open ```<central folder>\Artemis\src\Artemis.sln``` and build with the default config
-5. Clone Artemis.Plugins into  ```<central folder>\Artemis.Plugins```
-6. Open ```<central folder>\Artemis.Plugins\src\Artemis.Plugins.sln``` and build with the default config
+2. Clone Artemis into  ```<central folder>\Artemis```
+3. Open ```<central folder>\Artemis\src\Artemis.sln``` and build with the default config
+4. Clone Artemis.Plugins into  ```<central folder>\Artemis.Plugins```
+5. Open ```<central folder>\Artemis.Plugins\src\Artemis.Plugins.sln``` and build with the default config

--- a/src/Collections/Artemis.Plugins.Audio/Artemis.Plugins.Audio.csproj
+++ b/src/Collections/Artemis.Plugins.Audio/Artemis.Plugins.Audio.csproj
@@ -1,38 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Audio</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Audio</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="NAudio" Version="2.0.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MathNet.Numerics" Version="4.11.0">
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <Reference Include="Artemis.Core">
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
@@ -45,44 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PluginJson Include="plugin.json" />
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-  <UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <AssemblyName ParameterType="System.String" Required="true" />
-      <Json ParameterType="System.String" Required="true" />
-      <PluginPath ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Code Type="Fragment" Language="C#">
-        <![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Collections/Artemis.Plugins.Input/Artemis.Plugins.Input.csproj
+++ b/src/Collections/Artemis.Plugins.Input/Artemis.Plugins.Input.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Platforms>x64</Platforms>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
@@ -18,10 +18,6 @@
   <ItemGroup>
     <Reference Include="Artemis.Core">
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Collections/Artemis.Plugins.Input/Artemis.Plugins.Input.csproj
+++ b/src/Collections/Artemis.Plugins.Input/Artemis.Plugins.Input.csproj
@@ -1,35 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Input</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Input</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
 
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,57 +24,10 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Collections/Artemis.Plugins.PhilipsHue/Artemis.Plugins.PhilipsHue.csproj
+++ b/src/Collections/Artemis.Plugins.PhilipsHue/Artemis.Plugins.PhilipsHue.csproj
@@ -1,41 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.PhilipsHue</AssemblyName>
-    <RootNamespace>Artemis.Plugins.PhilipsHue</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Q42.HueApi" Version="3.18.1" />
-    <PackageReference Include="Q42.HueApi.ColorConverters" Version="3.18.1" />
-    <PackageReference Include="Q42.HueApi.Entertainment" Version="3.18.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Q42.HueApi" Version="3.18.1" />
+    <PackageReference Include="Q42.HueApi.Entertainment" Version="3.18.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,82 +43,15 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="Properties\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Resources\hue.svg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Views\PhilipsHueConfigurationView.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </None>
   </ItemGroup>
 
   <ItemGroup>
     <Resource Include="Resources\pushlink_bridge_v2.png" />
+    <Content Include="Resources\hue.svg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
+  <ItemGroup>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
+  </ItemGroup>
 </Project>

--- a/src/Collections/Artemis.Plugins.WebAPI/Artemis.Plugins.WebAPI.csproj
+++ b/src/Collections/Artemis.Plugins.WebAPI/Artemis.Plugins.WebAPI.csproj
@@ -1,34 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.WebAPI</AssemblyName>
-    <RootNamespace>Artemis.Plugins.WebAPI</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EmbedIO" Version="3.4.3" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
+    <PackageReference Include="EmbedIO" Version="3.4.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
 
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,50 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Collections/Artemis.Plugins.WebAPI/Artemis.Plugins.WebAPI.csproj
+++ b/src/Collections/Artemis.Plugins.WebAPI/Artemis.Plugins.WebAPI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Platforms>x64</Platforms>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
@@ -18,10 +18,6 @@
   <ItemGroup>
     <Reference Include="Artemis.Core">
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.Asus/Artemis.Plugins.Devices.Asus.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Asus/Artemis.Plugins.Devices.Asus.csproj
@@ -24,10 +24,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.Asus/Artemis.Plugins.Devices.Asus.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Asus/Artemis.Plugins.Devices.Asus.csproj
@@ -1,38 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <PreserveCompilationContext>false</PreserveCompilationContext>
-    <AssemblyName>Artemis.Plugins.Devices.Asus</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Asus</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="x64\**" />
-    <Compile Remove="x86\**" />
-    <EmbeddedResource Remove="x64\**" />
-    <EmbeddedResource Remove="x86\**" />
-    <None Remove="x64\**" />
-    <None Remove="x86\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="RGB.NET.Devices.Asus" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,62 +31,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Asus">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Asus.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.CoolerMaster/Artemis.Plugins.Devices.CoolerMaster.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.CoolerMaster/Artemis.Plugins.Devices.CoolerMaster.csproj
@@ -25,10 +25,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.CoolerMaster/Artemis.Plugins.Devices.CoolerMaster.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.CoolerMaster/Artemis.Plugins.Devices.CoolerMaster.csproj
@@ -1,40 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <PreserveCompilationContext>false</PreserveCompilationContext>
-    <AssemblyName>Artemis.Plugins.Devices.CoolerMaster</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.CoolerMaster</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="x86\**" />
-    <EmbeddedResource Remove="x86\**" />
-    <None Remove="x86\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="x64\CMSDK.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="RGB.NET.Devices.CoolerMaster" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -49,62 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.CoolerMaster">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.CoolerMaster.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="x64\CMSDK.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Corsair/Artemis.Plugins.Devices.Corsair.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Corsair/Artemis.Plugins.Devices.Corsair.csproj
@@ -1,35 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <PreserveCompilationContext>false</PreserveCompilationContext>
-    <AssemblyName>Artemis.Plugins.Devices.Corsair</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Corsair</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="x86\**" />
-    <EmbeddedResource Remove="x86\**" />
-    <None Remove="x86\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="RGB.NET.Devices.Corsair" Version="1.0.0-prerelease1" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,68 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="x64\CUESDK.x64_2017.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="x64\CUESDK.x64_2017.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Corsair">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Corsair.dll</HintPath>
-    </Reference>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Corsair/Artemis.Plugins.Devices.Corsair.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Corsair/Artemis.Plugins.Devices.Corsair.csproj
@@ -25,10 +25,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.DMX/Artemis.Plugins.Devices.DMX.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.DMX/Artemis.Plugins.Devices.DMX.csproj
@@ -1,35 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.DMX</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.DMX</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <None Remove="Views\DMXConfigurationView.xaml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Ninject" Version="3.3.4" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0"  />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0"  />
+    <PackageReference Include="FluentValidation" Version="10.2.3"  />
+    <PackageReference Include="Ninject" Version="3.3.4"  />
+    <PackageReference Include="Serilog" Version="2.10.0"  />
+    <PackageReference Include="SkiaSharp" Version="2.80.3"  />
+    <PackageReference Include="Stylet" Version="1.3.6"  />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+  
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+  
+    <ItemGroup>
+    <PackageReference Include="RGB.NET.Devices.DMX" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,75 +45,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.DMX">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.DMX.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Update="Views\Dialogs\DeviceConfigurationDialogView.xaml">
-      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
-    </Page>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PluginJson Include="plugin.json" />
-  </ItemGroup>
-
-  <UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <AssemblyName ParameterType="System.String" Required="true" />
-      <Json ParameterType="System.String" Required="true" />
-      <PluginPath ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Code Type="Fragment" Language="C#">
-        <![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Debug/Artemis.Plugins.Devices.Debug.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Debug/Artemis.Plugins.Devices.Debug.csproj
@@ -1,34 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.Debug</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Debug</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <None Remove="Views\DebugConfigurationView.xaml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RGB.NET.Devices.Debug" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,65 +43,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Debug">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Debug.dll</HintPath>
-    </Reference>
-    <Reference Include="RGB.NET.Layout">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Layout.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <PluginJson Include="plugin.json" />
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-  <UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <AssemblyName ParameterType="System.String" Required="true" />
-      <Json ParameterType="System.String" Required="true" />
-      <PluginPath ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Code Type="Fragment" Language="C#">
-        <![CDATA[
-        Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-        string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-        PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Artemis.Plugins.Devices.Logitech.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Artemis.Plugins.Devices.Logitech.csproj
@@ -24,10 +24,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Artemis.Plugins.Devices.Logitech.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Artemis.Plugins.Devices.Logitech.csproj
@@ -1,43 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.Logitech</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Logitech</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="x86\**" />
-    <EmbeddedResource Remove="x86\**" />
-    <None Remove="x86\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="x64\LogitechLedEnginesWrapper.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="HidSharp" Version="2.1.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="RGB.NET.Devices.Logitech" Version="1.0.0-prerelease1" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,65 +31,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Logitech">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Logitech.dll</HintPath>
-    </Reference>
-    <Reference Include="RGB.NET.HID">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.HID.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="x64\LogitechLedEnginesWrapper.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <PluginJson Include="plugin.json" />
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-  <UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <AssemblyName ParameterType="System.String" Required="true" />
-      <Json ParameterType="System.String" Required="true" />
-      <PluginPath ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Code Type="Fragment" Language="C#">
-        <![CDATA[
-        Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-        string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-        PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-    
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Msi/Artemis.Plugins.Devices.Msi.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Msi/Artemis.Plugins.Devices.Msi.csproj
@@ -1,43 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.Msi</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Msi</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="Layouts\**" />
-    <Compile Remove="x86\**" />
-    <EmbeddedResource Remove="Layouts\**" />
-    <EmbeddedResource Remove="x86\**" />
-    <None Remove="Layouts\**" />
-    <None Remove="x86\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="x64\MysticLight_SDK.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="RGB.NET.Devices.Msi" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,59 +30,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Msi">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Msi.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="x64\MysticLight_SDK.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Msi/Artemis.Plugins.Devices.Msi.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Msi/Artemis.Plugins.Devices.Msi.csproj
@@ -23,10 +23,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.Novation/Artemis.Plugins.Devices.Novation.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Novation/Artemis.Plugins.Devices.Novation.csproj
@@ -1,43 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.Novation</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Novation</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="x64\**" />
-    <Compile Remove="x86\**" />
-    <EmbeddedResource Remove="x64\**" />
-    <EmbeddedResource Remove="x86\**" />
-    <None Remove="x64\**" />
-    <None Remove="x86\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Sanford.Multimedia.Midi" Version="6.6.0">
-      <NoWarn>NU1701</NoWarn>
-    </PackageReference>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="RGB.NET.Devices.Novation" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,62 +30,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Novation">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Novation.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Novation/Artemis.Plugins.Devices.Novation.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Novation/Artemis.Plugins.Devices.Novation.csproj
@@ -23,10 +23,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.OpenRGB/Artemis.Plugins.Devices.OpenRGB.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.OpenRGB/Artemis.Plugins.Devices.OpenRGB.csproj
@@ -1,27 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.OpenRGB</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.OpenRGB</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <UseWPF>true</UseWPF>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="OpenRGB.NET" Version="1.7.0" />
+    <!--<PackageReference Include="RGB.NET.Devices.OpenRGB" Version="1.7.0" />-->
   </ItemGroup>
 
   <ItemGroup>
@@ -33,80 +42,18 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
     <Reference Include="RGB.NET.Devices.OpenRGB">
       <HintPath>RGB.NET.Devices.OpenRGB.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="OpenRGB.svg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="OpenRGB.svg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="OpenRGBConfigurationDialogView.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </None>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <Content Include="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Razer/Artemis.Plugins.Devices.Razer.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Razer/Artemis.Plugins.Devices.Razer.csproj
@@ -1,40 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <PreserveCompilationContext>false</PreserveCompilationContext>
-    <AssemblyName>Artemis.Plugins.Devices.Razer</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Razer</RootNamespace>
     <Platforms>x64</Platforms>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <UseWPF>true</UseWPF>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HidSharp" Version="2.1.0" />
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HidSharp" Version="2.1.0" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0"  />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0"  />
+    <PackageReference Include="FluentValidation" Version="10.2.3"  />
+    <PackageReference Include="Serilog" Version="2.10.0"  />
+    <PackageReference Include="SkiaSharp" Version="2.80.3"  />
+    <PackageReference Include="Stylet" Version="1.3.6"  />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RGB.NET.Devices.Razer" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -49,65 +44,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Razer">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Razer.dll</HintPath>
-    </Reference>
-    <Reference Include="RGB.NET.HID">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.HID.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.SteelSeries/Artemis.Plugins.Devices.SteelSeries.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.SteelSeries/Artemis.Plugins.Devices.SteelSeries.csproj
@@ -1,26 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.SteelSeries</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.SteelSeries</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="HidSharp" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RGB.NET.Devices.SteelSeries" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,65 +30,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.SteelSeries">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.SteelSeries.dll</HintPath>
-    </Reference>
-    <Reference Include="RGB.NET.HID">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.HID.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.SteelSeries/Artemis.Plugins.Devices.SteelSeries.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.SteelSeries/Artemis.Plugins.Devices.SteelSeries.csproj
@@ -23,10 +23,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devices/Artemis.Plugins.Devices.WS281X/Artemis.Plugins.Devices.WS281X.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.WS281X/Artemis.Plugins.Devices.WS281X.csproj
@@ -1,43 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.WS281X</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.WS281X</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Views\WS281XConfigurationView.xaml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RGB.NET.Devices.WS281X" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,71 +44,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.WS281X">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.WS281X.dll</HintPath>
-    </Reference>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
-
-  <!--Workaround for the wrong System.IO.Ports being copied (https://github.com/dotnet/runtime/issues/25375) -->
-  <ItemGroup>
-    <TestPath Include="$(PublishDir)\runtimes" />
-  </ItemGroup>
-  <Target Name="SystemIOPortsWorkaround" AfterTargets="Publish" Condition="Exists(@(TestPath))">
-    <Copy SourceFiles="$(PublishDir)\runtimes\win\lib\netstandard2.0\System.IO.Ports.dll" DestinationFolder="$(PublishDir)" />
-    <RemoveDir Directories="$(PublishDir)\runtimes" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Wooting/Artemis.Plugins.Devices.Wooting.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Wooting/Artemis.Plugins.Devices.Wooting.csproj
@@ -1,28 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Devices.Wooting</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Devices.Wooting</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Remove="x86\**" />
-    <EmbeddedResource Remove="x86\**" />
-    <None Remove="x86\**" />
-    <Page Remove="x86\**" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <PackageReference Include="RGB.NET.Devices.Wooting" Version="1.0.0-prerelease1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,67 +29,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="x64\wooting-rgb-sdk64.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="Layouts\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="x64\wooting-rgb-sdk64.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="RGB.NET.Devices.Wooting">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Devices.Wooting.dll</HintPath>
-    </Reference>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <None Update="Images\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Layouts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Devices/Artemis.Plugins.Devices.Wooting/Artemis.Plugins.Devices.Wooting.csproj
+++ b/src/Devices/Artemis.Plugins.Devices.Wooting/Artemis.Plugins.Devices.Wooting.csproj
@@ -22,10 +22,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/Artemis.Plugins.LayerBrushes.Ambilight.csproj
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Ambilight/Artemis.Plugins.LayerBrushes.Ambilight.csproj
@@ -1,116 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>net5.0-windows</TargetFramework>
-		<ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-		<AssemblyName>Artemis.Plugins.LayerBrushes.Ambilight</AssemblyName>
-		<RootNamespace>Artemis.Plugins.LayerBrushes.Ambilight</RootNamespace>
-		<UseWPF>true</UseWPF>
-		<Platforms>x64</Platforms>
-		<GenerateDependencyFile>False</GenerateDependencyFile>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0-windows</TargetFramework>
+    <Platforms>x64</Platforms>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
-		<DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
-		<DebugSymbols>true</DebugSymbols>
-		<DebugType>full</DebugType>
-		<Optimize>false</Optimize>
-	</PropertyGroup>
+  <ItemGroup>
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
+  </ItemGroup>
 
-	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
-		<DebugType>pdbonly</DebugType>
-		<Optimize>true</Optimize>
-		<NoWarn>$(NoWarn);CS1591;CS1572;CS1573</NoWarn>
-		<DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-	</PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<PlatformTarget>x64</PlatformTarget>
-	</PropertyGroup>
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-		<PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-		<PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-		<PackageReference Include="ScreenCapture.NET" Version="1.0.2" />
-		<PackageReference Include="Serilog" Version="2.10.0" />
-		<PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-		<PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="ScreenCapture.NET" Version="1.0.2" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
-			<Generator>MSBuild:Compile</Generator>
-			<SubType>Designer</SubType>
-			<ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-		</Page>
-	</ItemGroup>
+  <ItemGroup>
+    <Reference Include="Artemis.Core">
+      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Artemis.UI.Shared">
+      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Reference Include="Artemis.Core">
-			<HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Artemis.UI.Shared">
-			<HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Update="plugin.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-	</ItemGroup>
-
-	<ItemGroup>
-		<Page Update="UI\CapturePropertiesView.xaml">
-			<XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
-			<SubType>Designer</SubType>
-		</Page>
-	</ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
+  <ItemGroup>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
+  </ItemGroup>
 </Project>

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Artemis.Plugins.LayerBrushes.Color.csproj
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Artemis.Plugins.LayerBrushes.Color.csproj
@@ -1,30 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.LayerBrushes.Color</AssemblyName>
-    <RootNamespace>Artemis.Plugins.LayerBrushes.Color</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,48 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="obj\x64\Debug\ColorBrushView.g.i.cs" />
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Artemis.Plugins.LayerBrushes.Color.csproj
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Color/Artemis.Plugins.LayerBrushes.Color.csproj
@@ -19,10 +19,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Noise/Artemis.Plugins.LayerBrushes.Noise.csproj
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Noise/Artemis.Plugins.LayerBrushes.Noise.csproj
@@ -19,10 +19,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Noise/Artemis.Plugins.LayerBrushes.Noise.csproj
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Noise/Artemis.Plugins.LayerBrushes.Noise.csproj
@@ -1,30 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.LayerBrushes.Noise</AssemblyName>
-    <RootNamespace>Artemis.Plugins.LayerBrushes.Noise</RootNamespace>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,44 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PluginJson Include="plugin.json" />
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-  <UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <AssemblyName ParameterType="System.String" Required="true" />
-      <Json ParameterType="System.String" Required="true" />
-      <PluginPath ParameterType="System.String" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Code Type="Fragment" Language="C#">
-        <![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Particle/Artemis.Plugins.LayerBrushes.Particle.csproj
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.Particle/Artemis.Plugins.LayerBrushes.Particle.csproj
@@ -1,34 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.LayerBrushes.Particle</AssemblyName>
-    <RootNamespace>Artemis.Plugins.LayerBrushes.Particle</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0"  />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0"  />
+    <PackageReference Include="FluentValidation" Version="10.2.3"  />
+    <PackageReference Include="SkiaSharp" Version="2.80.3"  />
+    <PackageReference Include="Stylet" Version="1.3.6"  />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,55 +35,10 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <!-- TODO: Replace with PackageReferences when moving to Nuget -->
-
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/LayerBrushes/Artemis.Plugins.LayerBrushes.RemoteControl/Artemis.Plugins.LayerBrushes.RemoteControl.csproj
+++ b/src/LayerBrushes/Artemis.Plugins.LayerBrushes.RemoteControl/Artemis.Plugins.LayerBrushes.RemoteControl.csproj
@@ -1,38 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.LayerBrushes.RemoteControl</AssemblyName>
-    <RootNamespace>Artemis.Plugins.LayerBrushes.RemoteControl</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EmbedIO" Version="3.4.3" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
+    <PackageReference Include="EmbedIO" Version="3.4.3"  />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0"  />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0"  />
+    <PackageReference Include="FluentValidation" Version="10.2.3"  />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3"  />
+    <PackageReference Include="Stylet" Version="1.3.6"  />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
 
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,57 +29,10 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/LayerEffects/Artemis.Plugins.LayerEffect.Strobe/Artemis.Plugins.LayerEffect.Strobe.csproj
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffect.Strobe/Artemis.Plugins.LayerEffect.Strobe.csproj
@@ -1,34 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.LayerEffect.Strobe</AssemblyName>
-    <RootNamespace>Artemis.Plugins.LayerEffect.Strobe</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
 
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,50 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/LayerEffects/Artemis.Plugins.LayerEffect.Strobe/Artemis.Plugins.LayerEffect.Strobe.csproj
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffect.Strobe/Artemis.Plugins.LayerEffect.Strobe.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Platforms>x64</Platforms>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
@@ -16,10 +16,6 @@
   <ItemGroup>
     <Reference Include="Artemis.Core">
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.Filter/Artemis.Plugins.LayerEffects.Filter.csproj
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.Filter/Artemis.Plugins.LayerEffects.Filter.csproj
@@ -1,31 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.LayerEffects.Filter</AssemblyName>
-    <RootNamespace>Artemis.Plugins.LayerEffects.Filter</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,45 +37,8 @@
     </Reference>
   </ItemGroup>
 
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
+  <ItemGroup>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
+  </ItemGroup>
 </Project>

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.LedReveal/Artemis.Plugins.LayerEffects.LedReveal.csproj
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.LedReveal/Artemis.Plugins.LayerEffects.LedReveal.csproj
@@ -19,10 +19,6 @@
       <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LayerEffects/Artemis.Plugins.LayerEffects.LedReveal/Artemis.Plugins.LayerEffects.LedReveal.csproj
+++ b/src/LayerEffects/Artemis.Plugins.LayerEffects.LedReveal/Artemis.Plugins.LayerEffects.LedReveal.csproj
@@ -1,34 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.LayerEffects.LedReveal</AssemblyName>
-    <RootNamespace>Artemis.Plugins.LayerEffects.LedReveal</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="RGB.NET.Core" Version="1.0.0-prerelease1" />
 
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,60 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="RGB.NET.Core">
-      <HintPath>..\..\..\..\RGB.NET\bin\net5.0\RGB.NET.Core.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
+    <Content Include="LedReveal.svg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="LedReveal.svg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Modules/Artemis.Plugins.Modules.General/Artemis.Plugins.Modules.General.csproj
+++ b/src/Modules/Artemis.Plugins.Modules.General/Artemis.Plugins.Modules.General.csproj
@@ -1,32 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Modules.General</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Modules.General</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,56 +38,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Images\bow.svg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Profiles\noise.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Profiles\rainbow.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="Images\bow.svg" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Profiles\noise.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Profiles\rainbow.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
+  <ItemGroup>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
+  </ItemGroup>
 </Project>

--- a/src/Modules/Artemis.Plugins.Modules.TestData/Artemis.Plugins.Modules.TestData.csproj
+++ b/src/Modules/Artemis.Plugins.Modules.TestData/Artemis.Plugins.Modules.TestData.csproj
@@ -1,27 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Modules.TestData</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Modules.TestData</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" PrivateAssets="All" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
+    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0"  />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0"  />
+    <PackageReference Include="FluentValidation" Version="10.2.3"  />
+    <PackageReference Include="Serilog" Version="2.10.0"  />
+    <PackageReference Include="SkiaSharp" Version="2.80.3"  />
+    <PackageReference Include="Stylet" Version="1.3.6"  />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,58 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true'">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
-  </ItemGroup>
-
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
 </Project>

--- a/src/Other/Artemis.Plugins.Profiling/Artemis.Plugins.Profiling.csproj
+++ b/src/Other/Artemis.Plugins.Profiling/Artemis.Plugins.Profiling.csproj
@@ -1,31 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.Profiling</AssemblyName>
-    <RootNamespace>Artemis.Plugins.Profiling</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.1.2" />
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
@@ -33,6 +13,22 @@
       <SubType>Designer</SubType>
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="Stylet" Version="1.3.6" />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -47,53 +43,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-	  <None Update="Resources\jetbrains.svg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="Resources\jetbrains.svg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
+  <ItemGroup>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
+  </ItemGroup>
 </Project>

--- a/src/ScriptingProviders/Artemis.Plugins.ScriptingProviders.JavaScript/Artemis.Plugins.ScriptingProviders.JavaScript.csproj
+++ b/src/ScriptingProviders/Artemis.Plugins.ScriptingProviders.JavaScript/Artemis.Plugins.ScriptingProviders.JavaScript.csproj
@@ -1,36 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <ShouldIncludeNativeSkiaSharp>false</ShouldIncludeNativeSkiaSharp>
-    <AssemblyName>Artemis.Plugins.ScriptingProviders.JavaScript</AssemblyName>
-    <RootNamespace>Artemis.Plugins.ScriptingProviders.JavaScript</RootNamespace>
-    <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
-    <GenerateDependencyFile>False</GenerateDependencyFile>
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-    <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>
-    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Jint" Version="3.0.0-beta-2032" />
-    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0" PrivateAssets="All" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="FluentValidation" Version="10.2.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.864.35" />
-    <PackageReference Include="Ninject" Version="3.3.4">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="ninject.extensions.conventions" Version="3.3.0" />
-    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" PrivateAssets="All" />
-    <PackageReference Include="Stylet" Version="1.3.6" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
@@ -38,6 +13,26 @@
       <SubType>Designer</SubType>
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignExtensions" Version="3.3.0"  />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0"  />
+    <PackageReference Include="FluentValidation" Version="10.2.3"  />
+    <PackageReference Include="Ninject" Version="3.3.4"/>
+    <PackageReference Include="ninject.extensions.conventions" Version="3.3.0" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3"  />
+    <PackageReference Include="Stylet" Version="1.3.6"  />
+
+    <!--All packages Artemis already references are compile-only dependencies-->
+    <PackageReference Update="@(PackageReference)" IncludeAssets="compile;build" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.864.35" />
+    <PackageReference Include="Jint" Version="3.0.0-beta-2032" />
   </ItemGroup>
 
   <ItemGroup>
@@ -50,78 +45,22 @@
       <Private>false</Private>
     </Reference>
   </ItemGroup>
-  
-    <ItemGroup>
-    <None Update="Editor\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+
+  <ItemGroup>
+    <Content Include="Editor\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="StaticDeclarations\LayerPropertyWrapper.ts">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <SubType>Code</SubType>
-    </None>
-    <None Update="StaticDeclarations\LayerWrapper.ts">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <SubType>Code</SubType>
-    </None>
-    <None Update="StaticDeclarations\InputWrapper.ts">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="StaticDeclarations\ProfileWrapper.ts">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Templates\GlobalScript.js">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Templates\ProfileScript.js">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Content Include="StaticDeclarations\LayerPropertyWrapper.ts" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="StaticDeclarations\LayerWrapper.ts" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="StaticDeclarations\InputWrapper.ts" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="StaticDeclarations\ProfileWrapper.ts" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Templates\GlobalScript.js" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Templates\ProfileScript.js" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-	<ItemGroup>
-		<PluginJson Include="plugin.json" />
-	</ItemGroup>
-
-	<UsingTask TaskName="GetPluginPath" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildBinPath)\Microsoft.Build.Tasks.Core.dll">
-		<ParameterGroup>
-			<AssemblyName ParameterType="System.String" Required="true" />
-			<Json ParameterType="System.String" Required="true" />
-			<PluginPath ParameterType="System.String" Output="true" />
-		</ParameterGroup>
-		<Task>
-			<Using Namespace="System" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.Text.RegularExpressions" />
-			<Code Type="Fragment" Language="C#">
-				<![CDATA[
-				Match guidMatch = Regex.Match(Json, "\"Guid\": \"([^\"]+)\"");
-				string guid = guidMatch.Groups.Count > 1 ? guidMatch.Groups[1].Value.Substring(0, 8) : "ffffffff";
-				PluginPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Artemis", "plugins", AssemblyName + "-" + guid);
-				]]>
-			</Code>
-		</Task>
-	</UsingTask>
-
-  <!-- Copy the plugin files to the Artemis plugin directory -->
-  <Target Name="PostBuildCopy" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Determine the file path based on plugin.json contents -->
-    <ReadLinesFromFile File="@(PluginJson)">
-      <Output TaskParameter="Lines" ItemName="JsonContents" />
-    </ReadLinesFromFile>
-    <GetPluginPath AssemblyName="$(AssemblyName)" Json="@(JsonContents)">
-      <Output TaskParameter="PluginPath" PropertyName="PluginPath" />
-    </GetPluginPath>
-
-    <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(PluginPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Message Text="Placed debug build in file:\\$(PluginPath)" Importance="High" />
-    <Message Text="To share your plugin with others, use 'dotnet publish'" Importance="High" />
-  </Target>
+  <ItemGroup>
+    <Content Include="plugin.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="ArtemisRGB.Plugins.BuildTask" Version="1.1.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the plugins to use the https://github.com/Artemis-RGB/Artemis.Plugins.BuildTask package and RGB.NET's NuGet packages.

References to WPF and Artemis.UI.Shared have also been removed where possible, easing the transition to Avalonia.