### PR TITLE
WS281X plugin - fixed an exception when DeviceDefinitions are loaded with null value

### DIFF
--- a/src/Devices/Artemis.Plugins.Devices.WS281X/ViewModels/WS281XConfigurationViewModel.cs
+++ b/src/Devices/Artemis.Plugins.Devices.WS281X/ViewModels/WS281XConfigurationViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reactive;
 using System.Threading.Tasks;
@@ -29,6 +29,10 @@ public class WS281XConfigurationViewModel : PluginConfigurationViewModel
         _pluginManagementService = pluginManagementService;
         _definitions = _settings.GetSetting("DeviceDefinitions", new List<DeviceDefinition>());
 
+        //DeviceDefinitions setting may be loaded with a null list
+        if (_definitions.Value == null)
+            _definitions.Value = new List<DeviceDefinition>();
+            
         Definitions = new ObservableCollection<DeviceDefinition>(_definitions.Value);
         TurnOffLedsOnShutdown = _settings.GetSetting("TurnOffLedsOnShutdown", false);
 


### PR DESCRIPTION
Pulled last build and still got this error:

System.ArgumentNullException: Value cannot be null. (Parameter 'collection')
   at System.Collections.ObjectModel.ObservableCollection1.CreateCopy(IEnumerable1 collection, String paramName)
   at System.Collections.ObjectModel.ObservableCollection1..ctor(IEnumerable1 collection)
   at Stylet.BindableCollection1..ctor(IEnumerable1 collection)
   at Artemis.Plugins.Devices.WS281X.ViewModels.WS281XConfigurationViewModel..ctor(Plugin plugin, PluginSettings settings, IDialogService dialogService, IPluginManagementService pluginManagementService) in C:\Hobby\Artemis-RGB\Artemis.Plugins\src\Devices\Artemis.Plugins.Devices.WS281X\ViewModels\WS281XConfigurationViewModel.cs:line 31
   at DynamicInjector4b5f0fd377c8424696c88b808aef5e99(Object[] )
   at Ninject.Activation.Context.ResolveInternal(Object scope)
   at Ninject.Activation.Context.Resolve()
   at Ninject.KernelBase.Resolve(IRequest request, Boolean handleMissingBindings)
   at Ninject.Extensions.ChildKernel.ChildKernel.Resolve(IRequest request)
   at Ninject.ResolutionExtensions.Get(IResolutionRoot root, Type service, IParameter[] parameters)
   at Artemis.UI.Screens.Settings.Tabs.Plugins.PluginSettingsViewModel.OpenSettings() in C:\Hobby\Artemis-RGB\Artemis\src\Artemis.UI\Screens\Settings\Tabs\Plugins\PluginSettingsViewModel.cs:line 101
   
At last decided to check this myself and discovered that 
_definitions = _settings.GetSetting("DeviceDefinitions", new List<DeviceDefinition>());
returns _definitions.Value == null so
obviously it can not bind to null collection and crashes on 
Definitions = new BindableCollection<DeviceDefinition>(_definitions.Value);

after I made a quick fix, setting it to 
 if (_definitions.Value == null)
       _definitions.Value = new List<DeviceDefinition>();