### PR TITLE
Update G403.xml, adding logitech logo led

### DIFF
--- a/src/Devices/Artemis.Plugins.Devices.Logitech/Layouts/Logitech/Mouse/G403.xml
+++ b/src/Devices/Artemis.Plugins.Devices.Logitech/Layouts/Logitech/Mouse/G403.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Device xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>Logitech G403</Name>
   <Description>Layout of the Logitech G403 Mouse</Description>
@@ -10,12 +10,16 @@
   <Height>125</Height>
   <Leds>
     <Led Id="Mouse1">
-      <Shape>m 0.7025,0.00275 -0.15,0 -0,0.26 h 0.15 z m -0.16732,0.7925 c -0.7,0.0159 -0.55,0.19383 -0.006236,0.19067 l 0.001707,-0.0416 c -0.425,-0.0115 -0.225,-0.11 0.005116,-0.10 z m 0.410,0.0779 -0.435,0 0,0.0401 0.225,0 0,0.0437 0.21,0 z</Shape>
-      <X>24.1</X>
-      <Y>16.4</Y>
-      <Width>17mm</Width>
-      <Height>81mm</Height>
+      <X>32.9</X>
+      <Y>15.4</Y>
+      <Width>4mm</Width>
+      <Height>21mm</Height>
     </Led>
+	<Led Id="Mouse2">
+		<Shape> M0.522,0.417 L0.92,0.417 L0.92,0.812 L0.731,0.812 L0.731,0.603 L0.516,0.603z M0.52,0.06 L0.402,0.075 L0.269,0.132 L0.19,0.199 L0.13,0.278 L0.093,0.362 L0.076,0.458 L0.074,0.537 L0.079,0.596 L0.098,0.646 L0.133,0.71 L0.177,0.771 L0.237,0.831 L0.311,0.878 L0.385,0.912 L0.454,0.922 L0.516,0.925 L0.516,0.759 L0.414,0.739 L0.333,0.675 L0.283,0.586 L0.266,0.502 L0.281,0.411 L0.338,0.325 L0.422,0.268 L0.474,0.253 L0.52,0.253z</Shape>
+		<X>22.9</X>
+		<Y>79.3</Y>
+	</Led>
   </Leds>
   <CustomData>
     <DeviceImage>G403-G703.png</DeviceImage>


### PR DESCRIPTION
In the previous version of the file, the logo wasn't included as a second led, so the software was unable to manage the logo's led. 

I deleted the old shape of "Mouse1", resized the square, added a "Mouse2", copied the shape from G502.xml and reajusted it.